### PR TITLE
Use XDG_CONFIG_HOME if it's available

### DIFF
--- a/src/cmdlib.cpp
+++ b/src/cmdlib.cpp
@@ -860,6 +860,26 @@ FString ExpandEnvVars(const char *searchpathstring)
 
 //==========================================================================
 //
+// ExpandEnvVarFallback
+//
+// Expands environment variable references in a string. Intended primarily
+// for use with IWAD search paths in config files.
+// If the environment variable is not defined or empty, use the given fallback.
+//==========================================================================
+
+FString ExpandEnvVarFallback(const char *varname, const char *fallback) {
+	char *value = getenv (varname);
+	FString out;
+	if (value == NULL || strlen (value) == 0)
+		out += ExpandEnvVars (fallback);
+	else
+		out += value;
+
+	return out;
+}
+
+//==========================================================================
+//
 // NicePath
 //
 // Handles paths with leading ~ characters on Unix as well as environment

--- a/src/cmdlib.h
+++ b/src/cmdlib.h
@@ -52,6 +52,7 @@ char *CleanseString (char *str);
 
 void CreatePath(const char * fn);
 
+FString ExpandEnvVarFallback(const char *varname, const char *fallback);
 FString ExpandEnvVars(const char *searchpathstring);
 FString NicePath(const char *path);
 

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -135,7 +135,8 @@ FGameConfigFile::FGameConfigFile ()
 		SetValueForKey ("Path", "$HOME", true);
 		SetValueForKey ("Path", "$PROGDIR", true);
 #else
-		SetValueForKey ("Path", "$HOME/" GAME_DIR, true);
+		SetValueForKey ("Path", (ExpandEnvVarFallback
+			("XDG_CONFIG_HOME", "$HOME/.config") + "/" GAME_DIR).GetChars (), true);
 		// Arch Linux likes them in /usr/share/doom
 		// Debian likes them in /usr/share/games/doom
 		// I assume other distributions don't do anything radically different
@@ -158,7 +159,8 @@ FGameConfigFile::FGameConfigFile ()
 #elif !defined(__unix__)
 		SetValueForKey ("Path", "$PROGDIR", true);
 #else
-		SetValueForKey ("Path", "$HOME/" GAME_DIR, true);
+		SetValueForKey ("Path", (ExpandEnvVarFallback
+			("XDG_CONFIG_HOME", "$HOME/.config") + "/" GAME_DIR).GetChars (), true);
 		SetValueForKey ("Path", SHARE_DIR, true);
 		SetValueForKey ("Path", "/usr/local/share/doom", true);
 		SetValueForKey ("Path", "/usr/local/share/games/doom", true);
@@ -180,7 +182,8 @@ FGameConfigFile::FGameConfigFile ()
 #elif !defined(__unix__)
 		SetValueForKey("Path", "$PROGDIR/soundfonts", true);
 #else
-		SetValueForKey("Path", "$HOME/" GAME_DIR "/soundfonts", true);
+		SetValueForKey ("Path", (ExpandEnvVarFallback
+			("XDG_CONFIG_HOME", "$HOME/.config") + "/" GAME_DIR "/soundfonts").GetChars (), true);
 		SetValueForKey("Path", "/usr/local/share/doom/soundfonts", true);
 		SetValueForKey("Path", "/usr/local/share/games/doom/soundfonts", true);
 		SetValueForKey("Path", "/usr/share/doom/soundfonts", true);

--- a/src/posix/unix/i_specialpaths.cpp
+++ b/src/posix/unix/i_specialpaths.cpp
@@ -33,7 +33,6 @@
 **
 */
 
-#include <iostream>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include "i_system.h"
@@ -41,26 +40,6 @@
 
 #include "version.h"	// for GAMENAME
 
-
-//===========================================================================
-//
-// GetEnvironmentVariable												Unix
-//
-// Returns the nice path specified in the given environemnt variable.
-// If the env variable is not defined or empty, use the given fallback.
-//
-//===========================================================================
-
-FString GetEnvironmentVariable(const char* varname, FString fallback) {
-	char * env = strdup(getenv(varname));
-	if ( env == NULL || strcmp(env, "") == 0)
-	{
-		// environment variable not defined or empty
-		return NicePath(fallback.GetChars());
-	} else {
-		return NicePath(env);
-	}
-}
 
 FString GetUserFile (const char *file)
 {
@@ -74,18 +53,17 @@ FString GetUserFile (const char *file)
 		struct stat extrainfo;
 
 		// Sanity check for $HOME/.config
-		FString configPath = GetEnvironmentVariable("XDG_CONFIG_HOME", FString("$HOME/.config/"));
-		std::cout << "actual configPath: " << configPath.GetChars() << std::endl;
+		FString configPath = NicePath("$HOME/.config/");
 		if (stat (configPath, &extrainfo) == -1)
 		{
 			if (mkdir (configPath, S_IRUSR | S_IWUSR | S_IXUSR) == -1)
 			{
-				I_FatalError ("Failed to create %s directory:\n%s", configPath.GetChars(), strerror(errno));
+				I_FatalError ("Failed to create $HOME/.config directory:\n%s", strerror(errno));
 			}
 		}
 		else if (!S_ISDIR(extrainfo.st_mode))
 		{
-			I_FatalError ("%s must be a directory", configPath.GetChars());
+			I_FatalError ("$HOME/.config must be a directory");
 		}
 
 		// This can be removed after a release or two
@@ -132,8 +110,7 @@ FString M_GetAppDataPath(bool create)
 {
 	// Don't use GAME_DIR and such so that ZDoom and its child ports can
 	// share the node cache.
-	FString path = GetEnvironmentVariable("XDG_CONFIG_HOME", FString("$HOME/.config/"));
-	path += GAMENAMELOWERCASE;
+	FString path = NicePath("$HOME/.config/" GAMENAMELOWERCASE);
 	if (create)
 	{
 		CreatePath(path);
@@ -153,8 +130,7 @@ FString M_GetCachePath(bool create)
 {
 	// Don't use GAME_DIR and such so that ZDoom and its child ports can
 	// share the node cache.
-	FString path = GetEnvironmentVariable("XDG_CONFIG_HOME", FString("$HOME/.config/"));
-	path += "/zdoom/cache/";
+	FString path = NicePath("$HOME/.config/zdoom/cache");
 	if (create)
 	{
 		CreatePath(path);
@@ -227,8 +203,7 @@ FString M_GetConfigPath(bool for_reading)
 
 FString M_GetScreenshotsPath()
 {
-	FString path = GetEnvironmentVariable("XDG_CONFIG_HOME", FString("$HOME/")+GAME_DIR);
-	return path + "/screenshots/";
+	return NicePath("$HOME/" GAME_DIR "/screenshots/");
 }
 
 //===========================================================================
@@ -241,12 +216,12 @@ FString M_GetScreenshotsPath()
 
 FString M_GetSavegamesPath()
 {
-	return GetEnvironmentVariable("XDG_CONFIG_HOME", FString("$HOME/")+GAME_DIR);
+	return NicePath("$HOME/" GAME_DIR);
 }
 
 //===========================================================================
 //
-// M_GetDocumentsPath													Unix
+// M_GetDocumentsPath												Unix
 //
 // Returns the path to the default documents directory.
 //
@@ -254,5 +229,5 @@ FString M_GetSavegamesPath()
 
 FString M_GetDocumentsPath()
 {
-	return GetEnvironmentVariable("XDG_CONFIG_HOME", FString("$HOME/")+GAME_DIR);
+	return NicePath("$HOME/" GAME_DIR);
 }

--- a/src/posix/unix/i_specialpaths.cpp
+++ b/src/posix/unix/i_specialpaths.cpp
@@ -46,24 +46,25 @@ FString GetUserFile (const char *file)
 	FString path;
 	struct stat info;
 
-	path = NicePath("$HOME/" GAME_DIR "/");
+	path = ExpandEnvVarFallback("XDG_CONFIG_HOME", "$HOME/.config");
+	path += "/" GAME_DIR "/";
 
 	if (stat (path, &info) == -1)
 	{
 		struct stat extrainfo;
 
 		// Sanity check for $HOME/.config
-		FString configPath = NicePath("$HOME/.config/");
+		FString configPath = ExpandEnvVarFallback("XDG_CONFIG_HOME", "$HOME/.config");
 		if (stat (configPath, &extrainfo) == -1)
 		{
 			if (mkdir (configPath, S_IRUSR | S_IWUSR | S_IXUSR) == -1)
 			{
-				I_FatalError ("Failed to create $HOME/.config directory:\n%s", strerror(errno));
+				I_FatalError ("Failed to create %s directory:\n%s", configPath.GetChars(), strerror(errno));
 			}
 		}
 		else if (!S_ISDIR(extrainfo.st_mode))
 		{
-			I_FatalError ("$HOME/.config must be a directory");
+			I_FatalError ("%s must be a directory", configPath.GetChars());
 		}
 
 		// This can be removed after a release or two
@@ -110,7 +111,8 @@ FString M_GetAppDataPath(bool create)
 {
 	// Don't use GAME_DIR and such so that ZDoom and its child ports can
 	// share the node cache.
-	FString path = NicePath("$HOME/.config/" GAMENAMELOWERCASE);
+	FString path = ExpandEnvVarFallback("XDG_CONFIG_HOME", "$HOME/.config");
+	path += "/" GAME_DIR;
 	if (create)
 	{
 		CreatePath(path);
@@ -130,7 +132,8 @@ FString M_GetCachePath(bool create)
 {
 	// Don't use GAME_DIR and such so that ZDoom and its child ports can
 	// share the node cache.
-	FString path = NicePath("$HOME/.config/zdoom/cache");
+	FString path = ExpandEnvVarFallback("XDG_CONFIG_HOME", "$HOME/.config");
+	path += "/zdoom/cache/";
 	if (create)
 	{
 		CreatePath(path);
@@ -203,7 +206,8 @@ FString M_GetConfigPath(bool for_reading)
 
 FString M_GetScreenshotsPath()
 {
-	return NicePath("$HOME/" GAME_DIR "/screenshots/");
+	FString path = ExpandEnvVarFallback("XDG_CONFIG_HOME", "$HOME/.config");
+	return path + "/" GAME_DIR "/screenshots/";
 }
 
 //===========================================================================
@@ -216,7 +220,7 @@ FString M_GetScreenshotsPath()
 
 FString M_GetSavegamesPath()
 {
-	return NicePath("$HOME/" GAME_DIR);
+	return ExpandEnvVarFallback("XDG_CONFIG_HOME", "$HOME/.config") + "/" GAME_DIR;
 }
 
 //===========================================================================
@@ -229,5 +233,5 @@ FString M_GetSavegamesPath()
 
 FString M_GetDocumentsPath()
 {
-	return NicePath("$HOME/" GAME_DIR);
+	return ExpandEnvVarFallback("XDG_CONFIG_HOME", "$HOME/.config") + "/" GAME_DIR;
 }

--- a/src/version.h
+++ b/src/version.h
@@ -107,7 +107,7 @@ const char *GetVersionString();
 #if defined(__APPLE__) || defined(_WIN32)
 #define GAME_DIR GAMENAME
 #else
-#define GAME_DIR ".config/" GAMENAMELOWERCASE
+#define GAME_DIR GAMENAMELOWERCASE
 #endif
 
 


### PR DESCRIPTION
Hi! I've reworked the patch, now it works. :) I also changed some places that weren't in the original patch.
There is one more instance, in `src/d_iwad.cpp` in error message text. Right now the game would tell you to put IWADs to `~/.config/gzdoom`, but you must put them to $XDG_CONFIG_HOME/gzdoom, as it should be.
I've also added the same patch to my gzdoom-flatpak repo, hope you don't mind :)